### PR TITLE
Update for MSVS2022

### DIFF
--- a/lib/configure.js
+++ b/lib/configure.js
@@ -317,14 +317,14 @@ function configure (gyp, argv, callback) {
       argv.push('-I', common_gypi)
       argv.push('-Dlibrary=shared_library')
       argv.push('-Dvisibility=default')
-      argv.push('-Dnode_root_dir="' + nodeDir + '"')
+      argv.push('-Dnode_root_dir=' + nodeDir)
       if (process.platform === 'aix') {
-        argv.push('-Dnode_exp_file="' + node_exp_file + '"')
+        argv.push('-Dnode_exp_file=' + node_exp_file)
       }
-      argv.push('-Dnode_gyp_dir="' + nodeGypDir + '"')
-      argv.push('-Dnode_lib_file="' + nodeLibFile + '"')
-      argv.push('-Dnw_lib_file="' + nwLibFile + '"')
-      argv.push('-Dmodule_root_dir="' + process.cwd() + '"')
+      argv.push('-Dnode_gyp_dir=' + nodeGypDir)
+      argv.push('-Dnode_lib_file=' + nodeLibFile)
+      argv.push('-Dnw_lib_file=' + nwLibFile)
+      argv.push('-Dmodule_root_dir=' + process.cwd())
       argv.push('-Dnode_engine=' +
         (gyp.opts.node_engine || process.jsEngine || 'v8'))
       argv.push('--depth=.')

--- a/lib/configure.js
+++ b/lib/configure.js
@@ -92,7 +92,7 @@ function configure (gyp, argv, callback) {
       if (err) return callback(err)
       log.verbose('build dir', '"build" dir needed to be created?', isNew)
       if (win && (!gyp.opts.msvs_version || gyp.opts.msvs_version === '2017' ||
-                 gyp.opts.msvs_version === '2019')) {
+                 gyp.opts.msvs_version === '2019' || gyp.opts.msvs_version === '2022')) {
         findVS(semver.parse(process.version), gyp.opts.msvs_version, function (err, vsSetup) {
           if (err) {
             log.verbose('Not using VS:', err.message)


### PR DESCRIPTION
Additionally requires replacing `clang/clang-cl.exe` and `clang/lld-link.exe` with an updated version >= 17.0.0